### PR TITLE
Fixed SD_TOOL_BAR_CONTENT.is_menu_bar if items is empty

### DIFF
--- a/Src/library/docking/sd_tool_bar_content.e
+++ b/Src/library/docking/sd_tool_bar_content.e
@@ -444,7 +444,9 @@ feature -- Query
 	is_menu_bar: BOOLEAN
 			-- If Current is a menu bar which only contain SD_TOOL_BAR_MENU_ITEM.
 		do
-			Result := ∀ i: items ¦ attached {SD_TOOL_BAR_MENU_ITEM} i
+			if not items.is_empty then
+				Result := ∀ i: items ¦ attached {SD_TOOL_BAR_MENU_ITEM} i
+			end
 		end
 
 	hash_code: INTEGER
@@ -682,7 +684,7 @@ invariant
 
 note
 	library: "SmartDocking: Library of reusable components for Eiffel."
-	copyright: "Copyright (c) 1984-2021, Eiffel Software and others"
+	copyright: "Copyright (c) 1984-2024, Eiffel Software and others"
 	license: "Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
 			Eiffel Software


### PR DESCRIPTION
SD_TOOL_BAR_CONTENT.is_menu_bar returns False again (like it did before its last change) if items is empty.

Steps to reproduce:
- Open project from EiffelStudio examples: docking/docking_control
- Compile and run
- In „Control Panel“ window switch to tab „Tool Bars“ and click on button „Create Tool Bar“:
    - Error message: „Catcall detected in {SD_TOOL_BAR}.extend for arg#1: expected SD_TOOL_BAR_MENU_ITEM but got SD_TOOL_BAR_NARROW_BUTTON“
    - Debugger: SD_MENU_BAR.extend

The error occurs because SD_TOOL_BAR_CONTENT.is_menu_bar returned True even there were no items. This changed in commit a410ca6 (regression). Previously there was a check for items.is_empty which I now reintroduced.

I could image that this is not the only code change that updated to the symbolic loop form and now behaves differently. But I haven't found any similar case in the commit mentioned above.

See also my post: https://groups.google.com/g/eiffel-users/c/DvV2E5mqBKU